### PR TITLE
Deploy with generic name

### DIFF
--- a/deploy/gcr/deploy.sh
+++ b/deploy/gcr/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-gcloud run deploy go-cicd-${TRAVIS_BRANCH}-${TRAVIS_BUILD_ID} --image ${CONTAINER_TAG}:${TRAVIS_COMMIT} --region us-east1 --platform managed --allow-unauthenticated
+gcloud run deploy go-cicd-${TRAVIS_BRANCH} --image ${CONTAINER_TAG}:${TRAVIS_COMMIT} --region us-east1 --platform managed --allow-unauthenticated

--- a/scripts/app/app.sh
+++ b/scripts/app/app.sh
@@ -17,7 +17,7 @@ then
   if [ "$TRAVIS_BRANCH" == "" ]; then
     CURRENT_HOST=http://localhost:$PORT
   else
-    CURRENT_HOST=$(gcloud run services describe go-cicd-$TRAVIS_BRANCH-$TRAVIS_BUILD_ID  --platform managed --region us-east1 --format 'value(status.url)')
+    CURRENT_HOST=$(gcloud run services describe go-cicd-$TRAVIS_BRANCH  --platform managed --region us-east1 --format 'value(status.url)')
   fi
   HOST=$CURRENT_HOST go test ./tests/end2end
 fi


### PR DESCRIPTION
At moment to deploy the app on Google Cloud Run, the same deploy can be used instead of creating a dedicated deploy for each commit in the same branch. Google Cloud Run handles a particular revision at the same deploy.